### PR TITLE
Add files to run python env as docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+# Use Ubuntu 22.4
+FROM ubuntu:jammy
+
+# install python
+RUN apt-get update && apt-get install -y \
+    python3.9 \
+    python3-pip \
+    vim
+
+WORKDIR /app
+
+# install pip3 packages specified in requirements.txt file
+COPY requirements.txt .
+RUN pip3 install -r requirements.txt
+
+# Copy app_run code into image
+RUN mkdir -p /app/app_run
+COPY ./app_run /app/app_run/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
 # data-pipelines-reference
-Codes used for book O Reilly "Data Pipeline Pocket Reference" by James Densmore
+Codes used for learning materials on O Reilly's "Data Pipeline Pocket Reference" by James Densmore.
+
+### Purpose of Docker-Compose
+Added docker-compose.yml and docker-compose.override.ymml to assume IAM permissions from AWS when running script as docker container. Please visit https://aws.amazon.com/blogs/compute/a-guide-to-locally-testing-containers-with-amazon-ecs-local-endpoints-and-docker-compose/ for more details
+
+### .env file
+Create .env file in parent folder of this repository for sensitive environment variables such as passwords.
+
+Example of .env content:
+env=dev
+aws_rgn=us-west-2
+snowflake_password=xyz
+
+## Run docker container locally
+1. Setup .env in parent folder of repo
+2. Run command "docker-compose --env-file ../.env up --build -d" to build and run docker container
+3. Run command "docker exec -it {name_of_container} bash to test scripts inside container
+4. Run command "docker-compose down" when done testing to remove docker containers

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,48 @@
+version: "2"
+networks:
+    # This special network is configured so that the local metadata
+    # service can bind to the specific IP address that ECS uses
+    # in production
+    credentials_network:
+        driver: bridge
+        ipam:
+            config:
+                - subnet: "169.254.170.0/24"
+                  gateway: 169.254.170.1
+services:
+    # This container vends credentials to your containers
+    ecs-local-endpoints:
+        # The Amazon ECS Local Container Endpoints Docker Image
+        image: amazon/amazon-ecs-local-container-endpoints
+        container_name: aws-ecs-local-container-endpoints
+        volumes:
+          # Mount /var/run so we can access docker.sock and talk to Docker
+          - /var/run:/var/run
+          # Mount the shared configuration directory, used by the AWS CLI and AWS SDKs
+          # On Windows, this directory can be found at "%UserProfile%\.aws"
+          - $HOME/.aws/:/home/.aws/
+        environment:
+          # define the home folder; credentials will be read from $HOME/.aws
+          HOME: "/home"
+          # You can change which AWS CLI Profile is used
+          AWS_PROFILE: "my-legacy-sso"
+        networks:
+            credentials_network:
+                # This special IP address is recognized by the AWS SDKs and AWS CLI 
+                ipv4_address: "169.254.170.2"
+                
+    # Here we reference the application container that we are testing
+    # You can test multiple containers at a time, simply duplicate this section
+    # and customize it for each container, and give it a unique IP in 'credentials_network'.
+    app:
+        depends_on:
+            - ecs-local-endpoints
+        networks:
+            credentials_network:
+                ipv4_address: "169.254.170.3"
+        environment:
+          AWS_DEFAULT_REGION: "us-west-2"
+          AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: "/role/python_app"
+          env: ${env}
+          aws_rgn: ${aws_rgn}
+          #AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: "/creds"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: "2"
+services:
+  app:
+    container_name: data-pipelines-container
+    build:
+      # Build an image from the Dockerfile in the current directory
+      context: .
+    ports:
+      - 8080:80
+    environment:
+      PORT: "80"
+    stdin_open: true # docker run -i
+    tty: true        # docker run -t

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+configparser
+boto3
+pytz
+#requests
+#pandas

--- a/ztest_docker_compose.sh
+++ b/ztest_docker_compose.sh
@@ -1,0 +1,2 @@
+docker-compose down
+docker-compose --env-file ../.env up --build -d


### PR DESCRIPTION
Add files to run python env as docker container. Add docker compose related files to get role permission from AWS when running container locally.